### PR TITLE
Improve identity layout styling

### DIFF
--- a/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/ExternalLogin.cshtml
+++ b/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/ExternalLogin.cshtml
@@ -1,32 +1,26 @@
 @page
 @model ExternalLoginModel
 @{
-    ViewData["Title"] = "Register";
+    ViewData["Title"] = "Registrazione esterna";
+    ViewData["Subtitle"] = $"Associa l'account {Model.ProviderDisplayName}";
+    Layout = "/Pages/Shared/_LayoutAuthCard.cshtml";
 }
 
-<h1>@ViewData["Title"]</h1>
-<h2 id="external-login-title">Associate your @Model.ProviderDisplayName account.</h2>
-<hr />
-
-<p id="external-login-description" class="text-info">
-    You've successfully authenticated with <strong>@Model.ProviderDisplayName</strong>.
-    Please enter an email address for this site below and click the Register button to finish
-    logging in.
+<p class="text-info">
+    Hai effettuato l'autenticazione con <strong>@Model.ProviderDisplayName</strong>.
+    Inserisci un'email per questo sito e premi Registrati per completare.
 </p>
 
-<div class="row">
-    <div class="col-md-4">
-        <form asp-page-handler="Confirmation" asp-route-returnUrl="@Model.ReturnUrl" method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.Email" class="form-control" autocomplete="email" placeholder="Please enter your email."/>
-                <label asp-for="Input.Email" class="form-label"></label>
-                <span asp-validation-for="Input.Email" class="text-danger"></span>
-            </div>
-            <button type="submit" class="w-100 btn btn-lg btn-primary">Register</button>
-        </form>
+<form asp-page-handler="Confirmation" asp-route-returnUrl="@Model.ReturnUrl" method="post">
+    <hr />
+    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.Email" class="form-control" autocomplete="email" placeholder="name@example.com" />
+        <label asp-for="Input.Email" class="form-label"></label>
+        <span asp-validation-for="Input.Email" class="text-danger"></span>
     </div>
-</div>
+    <button type="submit" class="aih-auth-btn">Registrati</button>
+</form>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/ForgotPassword.cshtml
+++ b/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/ForgotPassword.cshtml
@@ -1,25 +1,21 @@
 @page
 @model ForgotPasswordModel
 @{
-    ViewData["Title"] = "Forgot your password?";
+    ViewData["Title"] = "Password dimenticata";
+    ViewData["Subtitle"] = "Inserisci la tua email.";
+    Layout = "/Pages/Shared/_LayoutAuthCard.cshtml";
 }
 
-<h1>@ViewData["Title"]</h1>
-<h2>Enter your email.</h2>
-<hr />
-<div class="row">
-    <div class="col-md-4">
-        <form method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
-                <label asp-for="Input.Email" class="form-label"></label>
-                <span asp-validation-for="Input.Email" class="text-danger"></span>
-            </div>
-            <button type="submit" class="w-100 btn btn-lg btn-primary">Reset Password</button>
-        </form>
+<form method="post">
+    <hr />
+    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
+        <label asp-for="Input.Email" class="form-label"></label>
+        <span asp-validation-for="Input.Email" class="text-danger"></span>
     </div>
-</div>
+    <button type="submit" class="aih-auth-btn">Reset Password</button>
+</form>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/Login.cshtml
+++ b/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/Login.cshtml
@@ -2,88 +2,67 @@
 @model LoginModel
 @{
     ViewData["Title"] = "Accedi";
+    ViewData["Subtitle"] = "Usa il tuo account per accedere ad AI HelpDesk.";
+    Layout = "/Pages/Shared/_LayoutAuthCard.cshtml";
 }
 
-<div class="aih-login-wrapper">
-    <div class="aih-login-card mud-elevation-3">
+<form id="account" method="post">
+    <hr />
+    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
 
-        <h2>@ViewData["Title"]</h2>
-        <div class="aih-login-subtitle">Usa il tuo account per accedere ad AI HelpDesk.</div>
+    <!-- Email -->
+    <div class="mb-3">
+        <label asp-for="Input.Email" class="form-label"></label>
+        <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
+        <span asp-validation-for="Input.Email" class="text-danger"></span>
+    </div>
 
-        <form id="account" method="post">
-            <hr />
-            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+    <!-- Password -->
+    <div class="mb-3">
+        <label asp-for="Input.Password" class="form-label"></label>
+        <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="Password" />
+        <span asp-validation-for="Input.Password" class="text-danger"></span>
+    </div>
 
-            <!-- Email -->
-            <div class="mb-3">
-                <label asp-for="Input.Email" class="form-label"></label>
-                <input asp-for="Input.Email"
-                       class="form-control"
-                       autocomplete="username"
-                       aria-required="true"
-                       placeholder="name@example.com" />
-                <span asp-validation-for="Input.Email" class="text-danger"></span>
-            </div>
+    <!-- Remember -->
+    <div class="form-check mb-3">
+        <input class="form-check-input" asp-for="Input.RememberMe" />
+        <label asp-for="Input.RememberMe" class="form-check-label">
+            @Html.DisplayNameFor(m => m.Input.RememberMe)
+        </label>
+    </div>
 
-            <!-- Password -->
-            <div class="mb-3">
-                <label asp-for="Input.Password" class="form-label"></label>
-                <input asp-for="Input.Password"
-                       class="form-control"
-                       autocomplete="current-password"
-                       aria-required="true"
-                       placeholder="Password" />
-                <span asp-validation-for="Input.Password" class="text-danger"></span>
-            </div>
+    <!-- Submit -->
+    <div class="mb-2">
+        <button id="login-submit" type="submit" class="aih-auth-btn">Accedi</button>
+    </div>
 
-            <!-- Remember -->
-            <div class="form-check mb-3">
-                <input class="form-check-input" asp-for="Input.RememberMe" />
-                <label asp-for="Input.RememberMe" class="form-check-label">
-                    @Html.DisplayNameFor(m => m.Input.RememberMe)
-                </label>
-            </div>
+    <!-- Links -->
+    <div class="aih-auth-links">
+        <p><a id="forgot-password" asp-page="./ForgotPassword">Password dimenticata?</a></p>
+        <p><a asp-page="./Register" asp-route-returnUrl="@Model.ReturnUrl">Nuovo utente? Registrati</a></p>
+        <p><a id="resend-confirmation" asp-page="./ResendEmailConfirmation">Rispedisci email di conferma</a></p>
+    </div>
+</form>
 
-            <!-- Submit -->
-            <div class="mb-2">
-                <button id="login-submit" type="submit" class="aih-login-btn">Accedi</button>
-            </div>
-
-            <!-- Links -->
-            <div class="aih-login-links">
-                <p><a id="forgot-password" asp-page="./ForgotPassword">Password dimenticata?</a></p>
-                <p><a asp-page="./Register" asp-route-returnUrl="@Model.ReturnUrl">Nuovo utente? Registrati</a></p>
-                <p><a id="resend-confirmation" asp-page="./ResendEmailConfirmation">Rispedisci email di conferma</a></p>
+@* External providers *@
+@if ((Model.ExternalLogins?.Count ?? 0) > 0)
+{
+    <div class="mt-4">
+        <div class="aih-extprov-title">Oppure accedi con</div>
+        <hr />
+        <form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post">
+            <div class="text-center">
+                @foreach (var provider in Model.ExternalLogins!)
+                {
+                    <button type="submit" class="btn btn-outline-primary aih-extprov-btn" name="provider" value="@provider.Name" title="Accedi con @provider.DisplayName">
+                        @provider.DisplayName
+                    </button>
+                }
             </div>
         </form>
-
-        @* External providers *@
-        @if ((Model.ExternalLogins?.Count ?? 0) > 0)
-        {
-            <div class="mt-4">
-                <div class="aih-extprov-title">Oppure accedi con</div>
-                <hr />
-                <form id="external-account"
-                      asp-page="./ExternalLogin"
-                      asp-route-returnUrl="@Model.ReturnUrl"
-                      method="post">
-                    <div class="text-center">
-                        @foreach (var provider in Model.ExternalLogins!)
-                        {
-                            <button type="submit"
-                                    class="btn btn-outline-primary aih-extprov-btn"
-                                    name="provider"
-                                    value="@provider.Name"
-                                    title="Accedi con @provider.DisplayName">
-                                @provider.DisplayName
-                            </button>
-                        }
-                    </div>
-                </form>
-            </div>
-        }
     </div>
-</div>
+}
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/LoginWith2fa.cshtml
+++ b/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/LoginWith2fa.cshtml
@@ -1,37 +1,34 @@
 @page
 @model LoginWith2faModel
 @{
-    ViewData["Title"] = "Two-factor authentication";
+    ViewData["Title"] = "Autenticazione a due fattori";
+    ViewData["Subtitle"] = "Inserisci il codice dell'app di autenticazione.";
+    Layout = "/Pages/Shared/_LayoutAuthCard.cshtml";
 }
 
-<h1>@ViewData["Title"]</h1>
-<hr />
-<p>Your login is protected with an authenticator app. Enter your authenticator code below.</p>
-<div class="row">
-    <div class="col-md-4">
-        <form method="post" asp-route-returnUrl="@Model.ReturnUrl">
-            <input asp-for="RememberMe" type="hidden" />
-            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.TwoFactorCode" class="form-control" autocomplete="off" />
-                <label asp-for="Input.TwoFactorCode" class="form-label"></label>
-                <span asp-validation-for="Input.TwoFactorCode" class="text-danger"></span>
-            </div>
-            <div class="checkbox mb-3">
-                <label asp-for="Input.RememberMachine" class="form-label">
-                    <input asp-for="Input.RememberMachine" />
-                    @Html.DisplayNameFor(m => m.Input.RememberMachine)
-                </label>
-            </div>
-            <div>
-                <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
-            </div>
-        </form>
+<form method="post" asp-route-returnUrl="@Model.ReturnUrl">
+    <input asp-for="RememberMe" type="hidden" />
+    <hr />
+    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.TwoFactorCode" class="form-control" autocomplete="off" />
+        <label asp-for="Input.TwoFactorCode" class="form-label"></label>
+        <span asp-validation-for="Input.TwoFactorCode" class="text-danger"></span>
     </div>
-</div>
-<p>
-    Don't have access to your authenticator device? You can
-    <a id="recovery-code-login" asp-page="./LoginWithRecoveryCode" asp-route-returnUrl="@Model.ReturnUrl">log in with a recovery code</a>.
+    <div class="checkbox mb-3">
+        <label asp-for="Input.RememberMachine" class="form-label">
+            <input asp-for="Input.RememberMachine" />
+            @Html.DisplayNameFor(m => m.Input.RememberMachine)
+        </label>
+    </div>
+    <div>
+        <button type="submit" class="aih-auth-btn">Login</button>
+    </div>
+</form>
+
+<p class="mt-3">
+    Non hai accesso all'app di autenticazione?
+    <a id="recovery-code-login" asp-page="./LoginWithRecoveryCode" asp-route-returnUrl="@Model.ReturnUrl">Usa un codice di recupero</a>.
 </p>
 
 @section Scripts {

--- a/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml
+++ b/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml
@@ -1,28 +1,21 @@
 @page
 @model LoginWithRecoveryCodeModel
 @{
-    ViewData["Title"] = "Recovery code verification";
+    ViewData["Title"] = "Codice di recupero";
+    ViewData["Subtitle"] = "Inserisci il codice di recupero.";
+    Layout = "/Pages/Shared/_LayoutAuthCard.cshtml";
 }
 
-<h1>@ViewData["Title"]</h1>
-<hr />
-<p>
-    You have requested to log in with a recovery code. This login will not be remembered until you provide
-    an authenticator app code at log in or disable 2FA and log in again.
-</p>
-<div class="row">
-    <div class="col-md-4">
-        <form method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.RecoveryCode" class="form-control" autocomplete="off" placeholder="RecoveryCode" />
-                <label asp-for="Input.RecoveryCode" class="form-label"></label>
-                <span asp-validation-for="Input.RecoveryCode" class="text-danger"></span>
-            </div>
-            <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
-        </form>
+<form method="post">
+    <hr />
+    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.RecoveryCode" class="form-control" autocomplete="off" placeholder="RecoveryCode" />
+        <label asp-for="Input.RecoveryCode" class="form-label"></label>
+        <span asp-validation-for="Input.RecoveryCode" class="text-danger"></span>
     </div>
-</div>
+    <button type="submit" class="aih-auth-btn">Login</button>
+</form>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/Register.cshtml
+++ b/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/Register.cshtml
@@ -1,66 +1,57 @@
 @page
 @model RegisterModel
 @{
-    ViewData["Title"] = "Register";
+    ViewData["Title"] = "Registrati";
+    ViewData["Subtitle"] = "Crea un nuovo account.";
+    Layout = "/Pages/Shared/_LayoutAuthCard.cshtml";
 }
 
-<h1>@ViewData["Title"]</h1>
+<form id="registerForm" asp-route-returnUrl="@Model.ReturnUrl" method="post">
+    <hr />
+    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
+        <label asp-for="Input.Email">Email</label>
+        <span asp-validation-for="Input.Email" class="text-danger"></span>
+    </div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
+        <label asp-for="Input.Password">Password</label>
+        <span asp-validation-for="Input.Password" class="text-danger"></span>
+    </div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
+        <label asp-for="Input.ConfirmPassword">Confirm Password</label>
+        <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+    </div>
+    <button id="registerSubmit" type="submit" class="aih-auth-btn">Registrati</button>
+</form>
 
-<div class="row">
-    <div class="col-md-4">
-        <form id="registerForm" asp-route-returnUrl="@Model.ReturnUrl" method="post">
-            <h2>Create a new account.</h2>
-            <hr />
-            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
-                <label asp-for="Input.Email">Email</label>
-                <span asp-validation-for="Input.Email" class="text-danger"></span>
+<section class="mt-4">
+    <h3>Usa un servizio esterno per registrarti</h3>
+    <hr />
+    @{
+        if ((Model.ExternalLogins?.Count ?? 0) == 0)
+        {
+            <div>
+                <p>Non sono configurati provider di autenticazione esterni.</p>
             </div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
-                <label asp-for="Input.Password">Password</label>
-                <span asp-validation-for="Input.Password" class="text-danger"></span>
-            </div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
-                <label asp-for="Input.ConfirmPassword">Confirm Password</label>
-                <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
-            </div>
-            <button id="registerSubmit" type="submit" class="w-100 btn btn-lg btn-primary">Register</button>
-        </form>
-    </div>
-    <div class="col-md-6 col-md-offset-2">
-        <section>
-            <h3>Use another service to register.</h3>
-            <hr />
-            @{
-                if ((Model.ExternalLogins?.Count ?? 0) == 0)
-                {
-                    <div>
-                        <p>
-                            There are no external authentication services configured. See this <a href="https://go.microsoft.com/fwlink/?LinkID=532715">article
-                            about setting up this ASP.NET application to support logging in via external services</a>.
-                        </p>
-                    </div>
-                }
-                else
-                {
-                    <form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post" class="form-horizontal">
-                        <div>
-                            <p>
-                                @foreach (var provider in Model.ExternalLogins!)
-                                {
-                                    <button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
-                                }
-                            </p>
-                        </div>
-                    </form>
-                }
-            }
-        </section>
-    </div>
-</div>
+        }
+        else
+        {
+            <form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post" class="form-horizontal">
+                <div>
+                    <p>
+                        @foreach (var provider in Model.ExternalLogins!)
+                        {
+                            <button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Accedi con @provider.DisplayName">@provider.DisplayName</button>
+                        }
+                    </p>
+                </div>
+            </form>
+        }
+    }
+</section>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/ResendEmailConfirmation.cshtml
+++ b/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/ResendEmailConfirmation.cshtml
@@ -1,25 +1,21 @@
 @page
 @model ResendEmailConfirmationModel
 @{
-    ViewData["Title"] = "Resend email confirmation";
+    ViewData["Title"] = "Invia di nuovo la conferma";
+    ViewData["Subtitle"] = "Inserisci la tua email.";
+    Layout = "/Pages/Shared/_LayoutAuthCard.cshtml";
 }
 
-<h1>@ViewData["Title"]</h1>
-<h2>Enter your email.</h2>
-<hr />
-<div class="row">
-    <div class="col-md-4">
-        <form method="post">
-            <div asp-validation-summary="All" class="text-danger" role="alert"></div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.Email" class="form-control" aria-required="true" placeholder="name@example.com" />
-                <label asp-for="Input.Email" class="form-label"></label>
-                <span asp-validation-for="Input.Email" class="text-danger"></span>
-            </div>
-            <button type="submit" class="w-100 btn btn-lg btn-primary">Resend</button>
-        </form>
+<form method="post">
+    <hr />
+    <div asp-validation-summary="All" class="text-danger" role="alert"></div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.Email" class="form-control" aria-required="true" placeholder="name@example.com" />
+        <label asp-for="Input.Email" class="form-label"></label>
+        <span asp-validation-for="Input.Email" class="text-danger"></span>
     </div>
-</div>
+    <button type="submit" class="aih-auth-btn">Invia</button>
+</form>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/ResetPassword.cshtml
+++ b/AIHelpDesk.WebUI/Areas/Identity/Pages/Account/ResetPassword.cshtml
@@ -1,36 +1,32 @@
 @page
 @model ResetPasswordModel
 @{
-    ViewData["Title"] = "Reset password";
+    ViewData["Title"] = "Reimposta password";
+    ViewData["Subtitle"] = "Inserisci una nuova password.";
+    Layout = "/Pages/Shared/_LayoutAuthCard.cshtml";
 }
 
-<h1>@ViewData["Title"]</h1>
-<h2>Reset your password.</h2>
-<hr />
-<div class="row">
-    <div class="col-md-4">
-        <form method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
-            <input asp-for="Input.Code" type="hidden" />
-            <div class="form-floating mb-3">
-                <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
-                <label asp-for="Input.Email" class="form-label"></label>
-                <span asp-validation-for="Input.Email" class="text-danger"></span>
-            </div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please enter your password." />
-                <label asp-for="Input.Password" class="form-label"></label>
-                <span asp-validation-for="Input.Password" class="text-danger"></span>
-            </div>
-            <div class="form-floating mb-3">
-                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please confirm your password." />
-                <label asp-for="Input.ConfirmPassword" class="form-label"></label>
-                <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
-            </div>
-            <button type="submit" class="w-100 btn btn-lg btn-primary">Reset</button>
-        </form>
+<form method="post">
+    <hr />
+    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+    <input asp-for="Input.Code" type="hidden" />
+    <div class="form-floating mb-3">
+        <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
+        <label asp-for="Input.Email" class="form-label"></label>
+        <span asp-validation-for="Input.Email" class="text-danger"></span>
     </div>
-</div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Password" />
+        <label asp-for="Input.Password" class="form-label"></label>
+        <span asp-validation-for="Input.Password" class="text-danger"></span>
+    </div>
+    <div class="form-floating mb-3">
+        <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Confirm password" />
+        <label asp-for="Input.ConfirmPassword" class="form-label"></label>
+        <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+    </div>
+    <button type="submit" class="aih-auth-btn">Reset</button>
+</form>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/AIHelpDesk.WebUI/Pages/Shared/_LayoutAuthCard.cshtml
+++ b/AIHelpDesk.WebUI/Pages/Shared/_LayoutAuthCard.cshtml
@@ -1,0 +1,54 @@
+@using System.Linq
+@{
+    Layout = null;
+    var appTitle = "AI HelpDesk"; // TODO: tenant name
+
+    // returnUrl da querystring (supporta returnUrl o ReturnUrl)
+    var qs = Context?.Request?.Query;
+    string? ru = null;
+    if (qs?.ContainsKey("returnUrl") == true) { ru = qs["returnUrl"].FirstOrDefault(); }
+    else if (qs?.ContainsKey("ReturnUrl") == true) { ru = qs["ReturnUrl"].FirstOrDefault(); }
+    var returnUrl = string.IsNullOrWhiteSpace(ru) ? Url.Content("~/") : ru;
+    var subtitle = ViewData["Subtitle"] as string;
+}
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="utf-8" />
+    <title>@ViewData["Title"] - @appTitle</title>
+    <base href="~/" />
+    <link rel="stylesheet" href="~/bootstrap/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/variables.css" />
+    <link rel="stylesheet" href="~/css/site.css" />
+    <link rel="stylesheet" href="~/_content/MudBlazor/MudBlazor.min.css" />
+    <link rel="stylesheet" href="~/css/identity.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/identity.manage.css" asp-append-version="true" />
+</head>
+<body class="aih-auth-body">
+    <header class="aih-auth-appbar">
+        <a class="aih-auth-homebtn" href="@returnUrl" aria-label="Torna indietro">
+            <svg class="aih-auth-homebtn-icn" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path fill="currentColor" d="M19 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H19v-2z" />
+            </svg>
+            <span class="sr-only">Indietro</span>
+        </a>
+        <div class="aih-auth-appbar-content">
+            <span class="aih-auth-appbar-title">@appTitle</span>
+        </div>
+    </header>
+
+    <main class="aih-auth-main">
+        <div class="aih-auth-card mud-elevation-3">
+            <h2>@ViewData["Title"]</h2>
+            @if (!string.IsNullOrWhiteSpace(subtitle)) {
+                <div class="aih-auth-subtitle">@subtitle</div>
+            }
+            @RenderBody()
+        </div>
+    </main>
+
+    <script src="~/_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="~/_framework/blazor.web.js"></script>
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/AIHelpDesk.WebUI/wwwroot/css/identity.css
+++ b/AIHelpDesk.WebUI/wwwroot/css/identity.css
@@ -111,7 +111,7 @@
 /* ==============================
    LOGIN CARD
    ============================== */
-.aih-login-card {
+.aih-auth-card {
     width: 100%;
     max-width: 420px;
     padding: 1.5rem 2rem;
@@ -121,32 +121,32 @@
     text-align: left;
 }
 
-    .aih-login-card h2 {
+    .aih-auth-card h2 {
         text-align: center;
         margin-bottom: .5rem;
         font-weight: 600;
     }
 
-.aih-login-subtitle {
+.aih-auth-subtitle {
     text-align: center;
     font-size: .9rem;
     opacity: .7;
     margin-bottom: 1.25rem;
 }
 
-.aih-login-card hr {
+.aih-auth-card hr {
     margin: 1rem auto 1.5rem;
     opacity: .15;
 }
 
 /* campi */
-.aih-login-card .form-label {
+.aih-auth-card .form-label {
     font-size: .85rem;
     opacity: .8;
     margin-bottom: .25rem;
 }
 
-.aih-login-card .form-control {
+.aih-auth-card .form-control {
     background: var(--mud-palette-surface, #fff);
     border: 1px solid var(--mud-palette-lines-default, rgba(0,0,0,.23));
     border-radius: 4px;
@@ -154,19 +154,19 @@
     transition: border-color .1s, box-shadow .1s;
 }
 
-    .aih-login-card .form-control:focus {
+    .aih-auth-card .form-control:focus {
         border-color: var(--brand-auth, #1b6ec2);
         box-shadow: 0 0 0 2px rgba(27,110,194,.25);
         outline: none;
     }
 
 /* remember me */
-.aih-login-card .form-check-input {
+.aih-auth-card .form-check-input {
     margin-right: .25rem;
 }
 
 /* primary action */
-.aih-login-btn {
+.aih-auth-btn {
     width: 100%;
     padding: .75rem 1rem;
     font-size: 1rem;
@@ -178,26 +178,26 @@
     transition: background .15s;
 }
 
-    .aih-login-btn:hover,
-    .aih-login-btn:focus {
+    .aih-auth-btn:hover,
+    .aih-auth-btn:focus {
         background-color: #115293; /* darken */
     }
 
 /* links sotto */
-.aih-login-links {
+.aih-auth-links {
     margin-top: 1.5rem;
     text-align: center;
     font-size: .85rem;
 }
 
-    .aih-login-links p {
+    .aih-auth-links p {
         margin: .25rem 0;
     }
 
-    .aih-login-links a {
+    .aih-auth-links a {
         text-decoration: none;
     }
 
-        .aih-login-links a:hover {
+        .aih-auth-links a:hover {
             text-decoration: underline;
         }


### PR DESCRIPTION
## Summary
- add new `LayoutAuthCard` layout for authentication forms
- rename auth CSS classes and update pages
- update several account pages to use new layout

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878bb03675483269a35f1f25836b273